### PR TITLE
fix: correct Frechet derivatives for rays along the model boundary

### DIFF
--- a/src/fm2d/fm2dss.f90
+++ b/src/fm2d/fm2dss.f90
@@ -1854,7 +1854,7 @@ CONTAINS
 !     Test whether ray path segment extends beyond
 !     box boundaries
 !
-            IF (ipx .LT. 1) THEN
+            IF (rgx(j + 1) .LT. gox) THEN
                rgx(j + 1) = gox
                ipx = 1
                rbint = 1
@@ -1864,7 +1864,7 @@ CONTAINS
                ipx = nnx - 1
                rbint = 1
             END IF
-            IF (ipz .LT. 1) THEN
+            IF (rgz(j + 1) .LT. goz) THEN
                rgz(j + 1) = goz
                ipz = 1
                rbint = 1
@@ -2936,7 +2936,7 @@ CONTAINS
 !     Test whether ray path segment extends beyond
 !     box boundaries
 !
-            IF (ipx .LT. 1) THEN
+            IF (rgx(j + 1) .LT. gox) THEN
                rgx(j + 1) = gox
                ipx = 1
                rbint = 1
@@ -2946,7 +2946,7 @@ CONTAINS
                ipx = nnx - 1
                rbint = 1
             END IF
-            IF (ipz .LT. 1) THEN
+            IF (rgz(j + 1) .LT. goz) THEN
                rgz(j + 1) = goz
                ipz = 1
                rbint = 1
@@ -3511,7 +3511,7 @@ CONTAINS
 !     Test whether ray path segment extends beyond
 !     box boundaries
 !
-            IF (ipx .LT. 1) THEN
+            IF (rgx(j + 1) .LT. gox) THEN
                rgx(j + 1) = gox
                ipx = 1
                rbint = 1
@@ -3521,7 +3521,7 @@ CONTAINS
                ipx = nnx - 1
                rbint = 1
             END IF
-            IF (ipz .LT. 1) THEN
+            IF (rgz(j + 1) .LT. goz) THEN
                rgz(j + 1) = goz
                ipz = 1
                rbint = 1

--- a/src/pyfm2d/wavetracker.py
+++ b/src/pyfm2d/wavetracker.py
@@ -407,11 +407,23 @@ def _get_frechet_derivatives(cartesian, velocityderiv, velocity):
     frechetvals = fmm.get_frechet_derivatives()
     nx, ny = velocity.shape
 
-    # Remove cushion nodes and reshape
-    F = frechetvals.toarray()
+    # Reshape onto the padded (cushion) grid used internally by the Fortran solver.
+    F = frechetvals.toarray().reshape((-1, nx + 2, ny + 2))
     nrays = F.shape[0]
-    noncushion = _build_grid_noncushion_map(nx, ny)
-    F = F[:, noncushion.flatten()].reshape((nrays, nx, ny))
+
+    # Fold cushion-node derivatives back onto the adjacent boundary nodes.
+    # The cushion nodes simply duplicate the boundary velocity (see
+    # _build_velocity_grid), so any Frechet sensitivity assigned to them
+    # physically belongs to the neighbouring boundary node. Cropping them away
+    # (as was done previously) discards that weight and under-counts the
+    # derivative for rays that run along the model boundary. Folding rows first
+    # and then columns also routes the corner cushion nodes to the correct
+    # interior corner.
+    F[:, 1, :] += F[:, 0, :]
+    F[:, nx, :] += F[:, nx + 1, :]
+    F[:, :, 1] += F[:, :, 0]
+    F[:, :, ny] += F[:, :, ny + 1]
+    F = F[:, 1:nx + 1, 1:ny + 1]
 
     # For Spherical mode: reverse y order for consistency with ttfield array
     if not cartesian:
@@ -454,13 +466,6 @@ def _build_velocity_grid(v):
     vc[0, 0], vc[0, -1], vc[-1, 0], vc[-1, -1] = v[0, 0], v[0, -1], v[-1, 0], v[-1, -1]
 
     return vc
-
-
-def _build_grid_noncushion_map(nx, ny):
-    """Create boolean array identifying non-cushion nodes."""
-    noncushion = np.zeros((nx + 2, ny + 2), dtype=bool)
-    noncushion[1:nx + 1, 1:ny + 1] = True
-    return noncushion
 
 
 def _build_node_map(nx, ny):


### PR DESCRIPTION
The ray-born Frechet matrix (res.frechet) was wildly wrong for rays that run along a model boundary (e.g. short near-surface source-receiver pairs), with (J_s @ s)/tcal ratios up to ~1e11. Two distinct bugs:

1. Boundary overshoot (Fortran: rpaths, rpaths2, rpaths2_cart) The lower-boundary clamp tested the integer cell index (IF (ipx .LT. 1)). Fortran INT() truncates toward zero, so a ray point that drifted a fraction of a cell outside the grid still mapped to cell 1 and the clamp never fired. The out-of-cell point was then fed to the bilinear velocity interpolation, producing a wrong (even negative) velocity and a 1/vel**2 blow-up in the derivative. Switch the lower clamps to coordinate tests (rgx(j+1) < gox, rgz(j+1) < goz); the upper clamps were already coordinate-correct.

2. Cushion weight discarded (Python: _get_frechet_derivatives) Cushion nodes duplicate the boundary velocity, so their sensitivity belongs to the adjacent boundary node. The previous code cropped them away, under-counting the derivative for boundary-hugging rays. Fold the cushion rows/columns back onto the boundary nodes instead.

After both fixes (J_s @ s)/tcal is ~0.998-1.0 with no outliers on the issue-17 models (was 16/214/219 bad rows); 19/19 tests pass.