### PR TITLE
ci: finish Node 24 migration for release workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -34,11 +34,11 @@ jobs:
         with:
           output-dir: wheelhouse
         env:
-          CIBW_SKIP: pp* cp36* cp37* cp38* *-win32 *-manylinux_i686 *-musllinux_*
+          CIBW_SKIP: cp36* cp37* cp38* *-win32 *-manylinux_i686 *-musllinux_*
           MACOSX_DEPLOYMENT_TARGET: 14
 
       - name: Upload wheels as artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.os }}-wheelhouse
           path: wheelhouse
@@ -65,7 +65,7 @@ jobs:
           python -m build --sdist
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           path: dist/*.tar.gz
           name: sourcedist
@@ -79,7 +79,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           merge-multiple: true
           path: dist
@@ -97,13 +97,13 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           merge-multiple: true
           path: dist
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: dist/*


### PR DESCRIPTION
Follow-up to #19. The artifact action `v5` bumps and `action-gh-release@v2` still resolved to **Node 20**, so the `github-release` job kept emitting deprecation warnings on the v0.1.10 release run. This moves them to the actual Node 24 majors (verified against each action's `action.yml`):

| Action | Was | Now | Runtime |
|--------|-----|-----|---------|
| `actions/upload-artifact` | v5 | **v7** | node24 |
| `actions/download-artifact` | v5 | **v8** | node24 |
| `softprops/action-gh-release` | v2 | **v3** | node24 |

`upload-artifact@v7` and `download-artifact@v8` were released the same day and are the current compatible pair (the two actions version independently now).

Also drops the redundant `pp*` from `CIBW_SKIP` — cibuildwheel v3 no longer builds PyPy by default and warns on the unused selector.

After this, all jobs should be free of Node 20 deprecation warnings ahead of the June 16 2026 cutoff.